### PR TITLE
Update to oldest supported distro releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,23 @@ jobs:
       matrix:
         include:
           ## These are generally the oldest and newest releases that contain
-          ## Python >= 3.6 and are still maintained
+          ## Python >= 3.8 and are still maintained
           # https://en.wikipedia.org/wiki/Debian_version_history#Release_table
-          # https://packages.debian.org/buster/python3
+          # https://packages.debian.org/bullseye/python3
           - name: debian
-            version: 10
+            version: 11
           - name: debian
             version: stable
           # https://en.wikipedia.org/wiki/Fedora_(operating_system)#Releases
-          # https://mdapi.fedoraproject.org/f34/pkg/python3
+          # https://mdapi.fedoraproject.org/f37/pkg/python3
           - name: fedora
-            version: 34
+            version: 37
           - name: fedora
             version: latest
           # https://en.wikipedia.org/wiki/Ubuntu#Releases
-          # https://packages.ubuntu.com/bionic/python3
+          # https://packages.ubuntu.com/focal/python3
           - name: ubuntu
-            version: 18.04
+            version: 20.04
           - name: ubuntu
             version: rolling
     runs-on: ubuntu-latest


### PR DESCRIPTION
Please note that this implicitly updates the oldest tested Python version to 3.8, so I adapted the comment.